### PR TITLE
Major fixes for multi-arch builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,12 @@ catkin_package(
 set(ARDRONESDK3_DEVEL_PATH ${CMAKE_CURRENT_BINARY_DIR}/arsdk)
 set(ARDRONESDK3_PATH ${ARDRONESDK3_DEVEL_PATH}/src/ARSDKBuildUtils/out/arsdk-native/staging/usr)
 
-# 3.9.1
-set(ARSDK_ARCHIVE arsdk_3_9_1_stripped.tgz)
+# 3.9.1 patch 2
+set(ARSDK_ARCHIVE arsdk_3_9_1_p2_stripped.tgz)
+
+# Determine the architecure of the host in a robust way
+execute_process(COMMAND python ${PROJECT_SOURCE_DIR}/script/get_arch.py OUTPUT_VARIABLE BUILD_HOST_ARCH)
+message(STATUS "Host architecure: ${BUILD_HOST_ARCH}")
 
 add_custom_target(ARSDK_MKDIR
   COMMAND ${CMAKE_COMMAND} -E make_directory ${ARDRONESDK3_DEVEL_PATH})
@@ -26,11 +30,11 @@ include(ExternalProject)
 ExternalProject_Add(ARSDKBuildUtils
     DEPENDS ARSDK_MKDIR
     URL ${PROJECT_SOURCE_DIR}/sdk/${ARSDK_ARCHIVE}
-    URL_MD5 259678e3b9fe4e097fd12f6925fee646
+    URL_MD5 b0e8347e1cc2a605436cf39df6d0598c
     PREFIX ${ARDRONESDK3_DEVEL_PATH}
     CONFIGURE_COMMAND echo "No configure"
     # Setting TARGET_OS_FLAVOUR is experimental. The idea is to trick the build script to always pass the correct arch flags to all of underlying build scripts. This is useful when building the sdk for i386 targets inside a docker container which is running on a x86_64 host.
-    BUILD_COMMAND TARGET_OS_FLAVOUR=native-chroot ./build.sh -p arsdk-native -t build-sdk -j --no-color
+    BUILD_COMMAND TARGET_OS_FLAVOUR=native-chroot TARGET_ARCH=${BUILD_HOST_ARCH} ./build.sh -p arsdk-native -t build-sdk -j --no-color
     INSTALL_COMMAND echo "No SDK install command"
     BUILD_IN_SOURCE 1
 )

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>git</build_depend>
-  <build_depend>wget</build_depend>
   <build_depend>automake</build_depend>
   <build_depend>autoconf</build_depend>
   <build_depend>libtool</build_depend>

--- a/patch/alchemy_conditional_sse.patch
+++ b/patch/alchemy_conditional_sse.patch
@@ -1,0 +1,37 @@
+From c4de8682428bf770b1f88112014a7d86cf24d9e5 Mon Sep 17 00:00:00 2001
+From: schumacb <Bastian.Schumacher@gmx.de>
+Date: Mon, 4 Apr 2016 16:10:21 +0200
+Subject: [PATCH] Only enable SSE on Systems with x86 or x64 CPU
+
+This enables to build the SDK on raspberry pi.
+---
+ toolchains/linux/native/setup.mk | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/toolchains/linux/native/setup.mk b/toolchains/linux/native/setup.mk
+index 8ea89ad..7314ca6 100644
+--- a/toolchains/linux/native/setup.mk
++++ b/toolchains/linux/native/setup.mk
+@@ -29,10 +29,18 @@ ifeq ("$(TARGET_OS_FLAVOUR)","native-chroot")
+   TOOLCHAIN_LIBC := /
+ endif
+ 
+-TARGET_CPU_HAS_SSE2 := 1
+-TARGET_CPU_HAS_SSSE3 := 1
+-# -march=native seems better but this would most likely break distcc builds
+-TARGET_GLOBAL_CFLAGS += -msse -msse2 -mssse3
++# Enable SSE for x86 and x64
++ifeq ("$(TARGET_ARCH)","x64")
++  TARGET_CPU_HAS_SSE2 := 1
++  TARGET_CPU_HAS_SSSE3 := 1
++  # -march=native seems better but this would most likely break distcc builds
++  TARGET_GLOBAL_CFLAGS += -msse -msse2 -mssse3
++else ifeq ("$(TARGET_ARCH)","x86")
++  TARGET_CPU_HAS_SSE2 := 1
++  TARGET_CPU_HAS_SSSE3 := 1
++  # -march=native seems better but this would most likely break distcc builds
++  TARGET_GLOBAL_CFLAGS += -msse -msse2 -mssse3
++endif
+ 
+ # Get gdbserver path if available
+ TOOLCHAIN_GDBSERVER := $(wildcard /usr/bin/gdbserver)

--- a/script/download_and_strip_arsdk.sh
+++ b/script/download_and_strip_arsdk.sh
@@ -20,6 +20,7 @@ echo "y" | ./repo init -u https://github.com/Parrot-Developers/arsdk_manifests.g
 
 echo "Applying patches ..."
 cd ${TMP_WS}/build/dragon_build && git reset --hard && git apply ${CURRENT_DIR}/patch/dragon_disable_root_check.patch
+cd ${TMP_WS}/build/alchemy && git reset --hard && git apply ${CURRENT_DIR}/patch/alchemy_conditional_sse.patch
 cd $TMP_WS
 
 mv packages packages.git

--- a/script/get_arch.py
+++ b/script/get_arch.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# This script maps the output of `gcc -dumpmachine` to supported
+# platforms of alchemy (TARGET_ARCH variable).
+# `gcc -dumpmachine` is more reliable than `uname -a` inside docker containers
+# Refer to the CMakeLists.txt file for more information.
+
+from __future__ import print_function
+import subprocess
+
+try:
+  arch = subprocess.check_output(["gcc", "-dumpmachine"]).strip().split("-")[0]
+  if arch in ["aarch64", "arm64"]:
+    o = "aarch64"
+  elif arch in ["x86_64", "amd64"]:
+    o = "x64"
+  elif "arm" in arch:
+    o = "arm"
+  else:
+    o = "x86"
+  print(o, end='')
+except:
+  pass


### PR DESCRIPTION
- Add a patch to disable non-x86 compilation flags for arm platform from
  https://github.com/Parrot-Developers/alchemy/pull/6 by @schumacb
- Package a new patched and stripped SDK
- Add a script to determine the host arch robustly. This script is used
  by CMake to pass appropriate flags to build_sdk.py
- Remove redundant build dependencies
