### PR TITLE
Patch json-c_avoid_so_version SDK 3.12.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ catkin_package(
 set(ARDRONESDK3_DEVEL_PATH ${CMAKE_CURRENT_BINARY_DIR}/arsdk)
 set(ARDRONESDK3_PATH ${ARDRONESDK3_DEVEL_PATH}/src/ARSDKBuildUtils/out/arsdk-native/staging/usr)
 
-# 3.12.6 patch 0
-set(ARSDK_ARCHIVE arsdk_3_12_6_p0_stripped.tgz)
-set(ARSDK_ARCHIVE_MD5 8a88eab4b26d35508746442432276a1e)
+# 3.12.6 patch 1
+set(ARSDK_ARCHIVE arsdk_3_12_6_p1_stripped.tgz)
+set(ARSDK_ARCHIVE_MD5 134b533513045235e55134b47d1ba8d4)
 
 # Determine the architecure of the host in a robust way
 execute_process(COMMAND python ${PROJECT_SOURCE_DIR}/script/get_arch.py OUTPUT_VARIABLE BUILD_HOST_ARCH)

--- a/patch/json-c_avoid_so_version.patch
+++ b/patch/json-c_avoid_so_version.patch
@@ -1,0 +1,15 @@
+diff --git a/packages/ARSDKTools/json-c/atom.mk b/packages/ARSDKTools/json-c/atom.mk
+index a860442..36a890f 100644
+--- a/packages/ARSDKTools/json-c/atom.mk
++++ b/packages/ARSDKTools/json-c/atom.mk
+@@ -23,8 +23,9 @@ LOCAL_CREATE_LINKS += \
+ endif
+ 
+ # Remove so version for android shared libraries
+-ifeq ("$(TARGET_OS_FLAVOUR)","android")
+ LOCAL_AUTOTOOLS_PATCHES := 0001-android_avoid_so_version.patch
++ifeq ("$(TARGET_OS_FLAVOUR)","android")
++#LOCAL_AUTOTOOLS_PATCHES := 0001-android_avoid_so_version.patch
+ 
+ # If targetting an API level before 21, also apply the following patches
+ ifneq ("$(firstword $(sort $(TARGET_ANDROID_APILEVEL) 21))", "21")

--- a/script/download_and_strip_arsdk.sh
+++ b/script/download_and_strip_arsdk.sh
@@ -4,7 +4,7 @@ set -e
 
 ARSDK_MANIFEST_HASH="d7640c80ed7147971995222d9f4655932a904aa8"
 ARSDK_VERSION="3_12_6"
-PATCH_LEVEL="0"
+PATCH_LEVEL="1"
 
 TMP_WS=`mktemp -d`
 CURRENT_DIR=`pwd`
@@ -30,6 +30,9 @@ for f in `find ./packages.git -mindepth 1 -maxdepth 1 -type d`; do
   echo "Exporting $f ..."
   git archive --format=tar --prefix=`basename $f`/ --remote $f HEAD | (cd ./packages && tar xf - --exclude='TestBench/*')
 done
+
+echo "Applying package patches ..."
+git apply ${CURRENT_DIR}/patch/json-c_avoid_so_version.patch
 
 tar cfz $OUTPUT_ARCHIVE ./* --exclude "packages.git"
 cd $CURRENT_DIR


### PR DESCRIPTION
The main issue was that libjson-c.so is installed with full .so version. If you compile the SDK from source and check the "out/arsdk-native/staging/usr/lib" folder, you will see that this library is the only one with full .so.x.y.z version string. Apparently the SDK itself comes with a patch to disable this behavior. The catch is this patch is only applied on Android targets:

`cd /tmp/sdk312/packages/ARSDKTools/json-c`
 
The patch file is 0001-android_avoid_so_version.patch

In line 27 of the build configuration file (atom.mk), this patch is applied only for Android targets. Manually disabled this check so the patch applies regardless. This solved the issue locally, no libjson-c.so.x.y.z was created.

`# Remove so version for android shared libraries
LOCAL_AUTOTOOLS_PATCHES := 0001-android_avoid_so_version.patch
ifeq ("$(TARGET_OS_FLAVOUR)","android")
#LOCAL_AUTOTOOLS_PATCHES := 0001-android_avoid_so_version.patch`

Wrote a patch file to apply this change and put it inside the `patch` folder. Also updated the `download_and_strip.sh` script to apply patch.
